### PR TITLE
Fix return values types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- All returned maps have `{__serialize = 'map'}` set.
+  Cartridge CLI calls ExecTyped using connectors. Such calls expects map values,
+  but Lua empty tables are serialized as arrays by default.
+
 ## [1.1.0] - 2020-12-28
 
 ### Added

--- a/cartridge-cli-extensions/admin.lua
+++ b/cartridge-cli-extensions/admin.lua
@@ -80,6 +80,8 @@ function admin.register(func_name, func_usage, func_args, func_call)
         if not ok then
             return nil, string.format("func_args passed in bad format: %s", err)
         end
+    else
+        func_args = nil  -- box.NULL
     end
 
     if type(func_call) ~= 'function' then
@@ -108,7 +110,7 @@ end
 -- functions that are exposed for `cartridge admin`
 
 local function admin_list()
-    local list = {}
+    local list = setmetatable({}, {__serialize = 'map'})
 
     for func_name, func_spec in pairs(registry) do
         list[func_name] = {
@@ -130,7 +132,7 @@ local function admin_help(func_name)
 
     return {
         usage = registry[func_name].usage,
-        args = registry[func_name].args,
+        args = setmetatable(registry[func_name].args or {}, {__serialize = 'map'}),
     }
 end
 

--- a/test/admin_test.lua
+++ b/test/admin_test.lua
@@ -100,6 +100,11 @@ local test_funcs = {
         call = function() return 123 end
     },
 
+    func_empty_args = {
+        usage = 'Call some function w/ empty args',
+        call = function() end
+    },
+
     func_with_args = {
         usage = 'Call some function w/ args',
         args = {
@@ -151,14 +156,16 @@ g.test_list = function()
     local admin_list = rawget(_G, '__cartridge_admin_list')
 
     -- get functions list
-    t.assert_equals(admin_list(), {
+    local list_funcs = admin_list()
+    t.assert_equals(list_funcs, {
         func_no_args = {usage = test_funcs.func_no_args.usage},
         func_with_args = {usage = test_funcs.func_with_args.usage},
     })
+    t.assert_equals(getmetatable(list_funcs).__serialize, 'map')
 end
 
 g.test_help = function()
-    for _, name in ipairs({'func_no_args', 'func_with_args'}) do
+    for _, name in ipairs({'func_no_args', 'func_empty_args', 'func_with_args'}) do
         register_test_func(name)
     end
 
@@ -183,8 +190,18 @@ g.test_help = function()
     t.assert_equals(err, nil)
     t.assert_equals(help, {
         usage = test_funcs.func_no_args.usage,
-        args = nil,
+        args = {},
     })
+    t.assert_equals(getmetatable(help.args).__serialize, 'map')
+
+    -- func w/ empty args
+    local help, err = admin_help('func_empty_args')
+    t.assert_equals(err, nil)
+    t.assert_equals(help, {
+        usage = test_funcs.func_empty_args.usage,
+        args = {},
+    })
+    t.assert_equals(getmetatable(help.args).__serialize, 'map')
 
     -- func w/ args
     local help, err = admin_help('func_with_args')


### PR DESCRIPTION
All returned maps have `{__serialize = 'map'}` set.
Cartridge CLI calls ExecTyped using connectors. 
Such calls expects map values, but Lua empty tables are serialized as arrays by default.

Closes https://github.com/tarantool/cartridge-cli/issues/513